### PR TITLE
i18nVersion is regarded as a namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18next-localstorage-cache",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "caching layer for i18next using browsers localStorage",
   "main": "./index.js",
   "jsnext:main": "dist/es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ class Cache {
           // there should be no language version set, or if it is, it should match the one in translation
           this.options.versions[lng] === local.i18nVersion
         ) {
+          delete local.i18nVersion;
           store[lng] = local;
         }
       }


### PR DESCRIPTION
Cleaned up the version key on cached translations when pulling from cache

